### PR TITLE
fix: wrong vender id in PropertyList Filename

### DIFF
--- a/src/common/components/PlistContainer.jsx
+++ b/src/common/components/PlistContainer.jsx
@@ -56,7 +56,7 @@ export default class PlistContainer extends Component {
   }
   getFullPlistFilename() {
     const filePrefix = '/System/Library/Displays/Contents/Resources/Overrides/DisplayVendorID';
-    return `${filePrefix}-${this.encHelp.intToHex(this.state.plist.displayProductId)}/DisplayProductID-${this.encHelp.intToHex(this.state.plist.displayProductId)}`;
+    return `${filePrefix}-${this.encHelp.intToHex(this.state.plist.displayVendorId)}/DisplayProductID-${this.encHelp.intToHex(this.state.plist.displayProductId)}`;
   }
   downloadPlistAsFile() {
     const textFileAsBlob = new Blob([this.state.plistXmlString], { type: 'text/plain' });


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6239652/62096781-684ac280-b2b7-11e9-8d3a-2155691fa1a3.png)

Hi! Here is a typo and wasted me half an hour!

Just kidding, thx for the great tool. let's fix it and never confuse others.