### PR TITLE
Add NOTE for catalina read-only /System directory

### DIFF
--- a/src/common/components/App.js
+++ b/src/common/components/App.js
@@ -146,6 +146,11 @@ class App extends Component {
               </a>{" "}
               (at your own risk) to copy files to <code>/System/</code>.
             </p>
+            <p>
+              <strong>NOTE:</strong> On Mac OS Catalina systems, the <code>/System/</code> folder is mounted read-only, so
+              you may need to temporarily remount the file system as writable 
+              before copying the downloaded file as follows: <code>sudo mount -uw /</code>.  This lasts until the next reboot.
+            </p>
             <h5
               className={classNames(
                 appStyles.numberedList,


### PR DESCRIPTION
I found this step was necessary, so it might help to add this note to the page to aid other 10.15 or newer users who come across a filesystem that cannot be written to.