### PR TITLE
Command for creating file path on Catalina+

### DIFF
--- a/src/common/components/PlistContainer.jsx
+++ b/src/common/components/PlistContainer.jsx
@@ -292,7 +292,13 @@ export default class PlistContainer extends Component {
                     this.state.plist.displayVendorId,
                   )}/DisplayProductID-${this.encHelp.intToHex(this.state.plist.displayProductId)}`}
                 </code>
-                . This can be done without disabling System Integrity Protection.
+                . This can be done without disabling System Integrity Protection. If the file path 
+                does not exist, create it with{' '}
+                <code>
+                  {`sudo mkdir -p /Library/Displays/Contents/Resources/Overrides/DisplayVendorID-${this.encHelp.intToHex(
+                    this.state.plist.displayVendorId,
+                  )}`}
+                </code>
               </p>
               <h5
                 className={classNames(


### PR DESCRIPTION
Hey, thanks a lot for your work.

I struggled a bit to get it working (again), but in the end it helped to create the `/Library/...` file path before copying the Product file. Others might find this helpful too. After a reboot, it does work :)